### PR TITLE
feat: dark mode, drag&drop images, TOC in PDF, test suite

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -118,6 +118,34 @@ executable(
   install : true
 )
 
+# Tests: only markdown conversion and utils (no UI deps)
+test_sources = [
+  'src/test-marker.c',
+  'src/marker-markdown.c',
+  'src/marker-utils.c',
+  'src/marker-prefs.c',
+  'src/marker-editor.c',
+  'src/marker-window.c',
+  'src/marker-exporter.c',
+  'src/marker-source-view.c',
+  'src/marker-preview.c',
+  'src/marker-widget.c',
+  'src/marker-sketcher-window.c',
+  'src/marker.c',
+  res
+]
+
+test_exe = executable(
+  'marker-test',
+  sources : [test_sources, hoedown_sources],
+  dependencies : deps,
+  link_args: '-lm',
+  c_args: ['-DMARKER_TEST_BUILD'],
+  install : false
+)
+
+test('marker-tests', test_exe)
+
 install_data(
   'data/com.github.fabiocolacio.marker.svg',
   install_dir : join_paths(DATA_DIR, 'icons/hicolor/scalable/apps')

--- a/src/marker-markdown.c
+++ b/src/marker-markdown.c
@@ -184,10 +184,32 @@ html_footer(MarkerMathJSMode     mathjs_mode,
       break;
   }
 
-  char* buffer = g_strdup_printf("%s\n%s\n%s\n", mathjs_render, highlight_render, mermaid_render);
+  /* TOC generation script — inserts table of contents at top of document (#29) */
+  char *toc_script = g_strdup(
+    "<script>"
+    "document.addEventListener('DOMContentLoaded',function(){"
+    "var hs=document.querySelectorAll('h1,h2,h3');"
+    "if(hs.length<3)return;"
+    "var toc=document.createElement('div');"
+    "toc.innerHTML='<h2 style=\"page-break-before:avoid\">Table of Contents</h2>';"
+    "var ul=document.createElement('ul');"
+    "ul.style.cssText='list-style:none;padding:0;';"
+    "hs.forEach(function(h,i){"
+    "var li=document.createElement('li');"
+    "var indent=h.tagName==='H1'?0:h.tagName==='H2'?15:30;"
+    "li.style.cssText='margin-left:'+indent+'px;margin-bottom:4px;';"
+    "li.textContent=h.textContent;"
+    "ul.appendChild(li);});"
+    "toc.appendChild(ul);"
+    "toc.style.cssText='page-break-after:always;';"
+    "document.body.insertBefore(toc,document.body.firstChild);"
+    "});</script>");
+
+  char* buffer = g_strdup_printf("%s\n%s\n%s\n%s\n", mathjs_render, highlight_render, mermaid_render, toc_script);
   g_free(highlight_render);
   g_free(mathjs_render);
   g_free(mermaid_render);
+  g_free(toc_script);
   return buffer;
 }
 

--- a/src/marker-preview.c
+++ b/src/marker-preview.c
@@ -387,6 +387,25 @@ marker_preview_render_markdown(MarkerPreview* preview,
                                        css_theme,
                                        cursor);
 
+  /* Inject dark mode CSS when enabled (#21) */
+  if (marker_prefs_get_use_dark_theme()) {
+    char *dark_html = g_strdup_printf(
+      "%s<style>"
+      "body{background:#1e1e2e;color:#cdd6f4;}"
+      "a{color:#89b4fa;}"
+      "code,pre{background:#313244;color:#cdd6f4;}"
+      "table,th,td{border-color:#585b70;}"
+      "th{background:#313244;}"
+      "h1,h2,h3,h4,h5,h6{color:#cba6f7;}"
+      "blockquote{border-left-color:#585b70;color:#a6adc8;}"
+      ".mermaid svg text{fill:#cdd6f4 !important;}"
+      ".mermaid svg .edgePath path{stroke:#cdd6f4 !important;}"
+      ".mermaid svg .node rect,.mermaid svg .node polygon{fill:#313244 !important;stroke:#89b4fa !important;}"
+      "</style>", html);
+    free(html);
+    html = dark_html;
+  }
+
   WebKitWebView* web_view = WEBKIT_WEB_VIEW(preview);
 
   /* Re-enable JS and file access when MathJax, Highlight, or Mermaid need it (#2) */

--- a/src/marker-source-view.c
+++ b/src/marker-source-view.c
@@ -253,6 +253,48 @@ default_font_changed(GSettings*   settings,
 }
 
 static void
+drag_data_received_cb (GtkWidget        *widget,
+                       GdkDragContext   *context,
+                       gint              x,
+                       gint              y,
+                       GtkSelectionData *data,
+                       guint             info,
+                       guint             time,
+                       gpointer          user_data)
+{
+  gchar **uris = gtk_selection_data_get_uris (data);
+  if (!uris)
+    return;
+
+  MarkerSourceView *source_view = MARKER_SOURCE_VIEW (widget);
+  GtkTextBuffer *buffer = gtk_text_view_get_buffer (GTK_TEXT_VIEW (source_view));
+
+  for (int i = 0; uris[i] != NULL; i++) {
+    g_autofree gchar *path = g_filename_from_uri (uris[i], NULL, NULL);
+    if (!path)
+      continue;
+
+    /* Only accept image files */
+    g_autofree gchar *lower = g_ascii_strdown (path, -1);
+    if (!g_str_has_suffix (lower, ".png") &&
+        !g_str_has_suffix (lower, ".jpg") &&
+        !g_str_has_suffix (lower, ".jpeg") &&
+        !g_str_has_suffix (lower, ".gif") &&
+        !g_str_has_suffix (lower, ".svg") &&
+        !g_str_has_suffix (lower, ".webp"))
+      continue;
+
+    g_autofree gchar *img = g_strdup_printf ("![](%s)", path);
+    GtkTextIter iter;
+    gtk_text_buffer_get_iter_at_mark (buffer, &iter, gtk_text_buffer_get_insert (buffer));
+    gtk_text_buffer_insert (buffer, &iter, img, -1);
+  }
+
+  g_strfreev (uris);
+  gtk_drag_finish (context, TRUE, FALSE, time);
+}
+
+static void
 marker_source_view_init (MarkerSourceView *source_view)
 {
   GtkSourceSearchContext * search_context = gtk_source_search_context_new(GTK_SOURCE_BUFFER(gtk_text_view_get_buffer(GTK_TEXT_VIEW(source_view))),
@@ -277,6 +319,13 @@ marker_source_view_init (MarkerSourceView *source_view)
   if (marker_prefs_get_spell_check ()){
     gtk_spell_checker_attach (source_view->spell, GTK_TEXT_VIEW (source_view));
   }
+
+  /* Enable drag & drop for image files (#23) */
+  static GtkTargetEntry targets[] = { { "text/uri-list", 0, 0 } };
+  gtk_drag_dest_set (GTK_WIDGET (source_view), GTK_DEST_DEFAULT_ALL,
+                     targets, 1, GDK_ACTION_COPY);
+  g_signal_connect (source_view, "drag-data-received",
+                    G_CALLBACK (drag_data_received_cb), NULL);
 }
 
 static void

--- a/src/marker.c
+++ b/src/marker.c
@@ -378,6 +378,7 @@ marker_quit()
   }
 }
 
+#ifndef MARKER_TEST_BUILD
 int
 main(int    argc,
      char** argv)
@@ -400,3 +401,4 @@ main(int    argc,
 
   return status;
 }
+#endif /* MARKER_TEST_BUILD */

--- a/src/test-marker.c
+++ b/src/test-marker.c
@@ -1,0 +1,90 @@
+/*
+ * test-marker.c — Basic test suite for Marker
+ */
+
+#include <glib.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "marker-markdown.h"
+#include "marker-utils.h"
+#include "marker-prefs.h"
+
+static void
+test_markdown_to_html_headings (void)
+{
+  char *html = marker_markdown_to_html ("# Hello", 7, NULL,
+                                        MATHJS_OFF, HIGHLIGHT_OFF, MERMAID_OFF,
+                                        NULL, -1);
+  g_assert_nonnull (html);
+  g_assert_true (strstr (html, "Hello") != NULL);
+  free (html);
+}
+
+static void
+test_markdown_to_html_code_block (void)
+{
+  const char *md = "```c\nint x = 1;\n```";
+  char *html = marker_markdown_to_html (md, strlen (md), NULL,
+                                        MATHJS_OFF, HIGHLIGHT_OFF, MERMAID_OFF,
+                                        NULL, -1);
+  g_assert_nonnull (html);
+  g_assert_true (strstr (html, "<code") != NULL);
+  free (html);
+}
+
+static void
+test_markdown_to_html_mermaid_block (void)
+{
+  const char *md = "```mermaid\ngraph TD\n  A-->B\n```";
+  char *html = marker_markdown_to_html (md, strlen (md), NULL,
+                                        MATHJS_OFF, HIGHLIGHT_OFF, MERMAID_OFF,
+                                        NULL, -1);
+  g_assert_nonnull (html);
+  /* Mermaid blocks should produce a div with class mermaid */
+  g_assert_true (strstr (html, "mermaid") != NULL);
+  free (html);
+}
+
+static void
+test_read_file_nonexistent (void)
+{
+  long size = 0;
+  g_test_expect_message (NULL, G_LOG_LEVEL_WARNING, "*cannot open*");
+  gchar *contents = marker_utils_read_file ("/nonexistent/file.md", &size);
+  g_test_assert_expected_messages ();
+  g_assert_null (contents);
+  g_assert_cmpint (size, ==, 0);
+}
+
+static void
+test_read_file_valid (void)
+{
+  /* Write a temp file and read it back */
+  const char *text = "# Test\nHello world";
+  g_autofree gchar *path = g_build_filename (g_get_tmp_dir (), "marker_test.md", NULL);
+  g_file_set_contents (path, text, -1, NULL);
+
+  long size = 0;
+  gchar *contents = marker_utils_read_file (path, &size);
+  g_assert_nonnull (contents);
+  g_assert_cmpint (size, >, 0);
+  g_assert_true (strstr (contents, "Hello world") != NULL);
+  g_free (contents);
+  remove (path);
+}
+
+int
+main (int argc, char **argv)
+{
+  g_test_init (&argc, &argv, NULL);
+  marker_prefs_load ();
+
+  g_test_add_func ("/markdown/headings", test_markdown_to_html_headings);
+  g_test_add_func ("/markdown/code-block", test_markdown_to_html_code_block);
+  g_test_add_func ("/markdown/mermaid-block", test_markdown_to_html_mermaid_block);
+  g_test_add_func ("/utils/read-file-nonexistent", test_read_file_nonexistent);
+  g_test_add_func ("/utils/read-file-valid", test_read_file_valid);
+
+  return g_test_run ();
+}


### PR DESCRIPTION
Closes #21, Closes #23, Closes #27, Closes #29

- **#21** Dark mode CSS for preview pane and Mermaid diagrams
- **#23** Drag & drop images into editor (png, jpg, gif, svg, webp)
- **#27** Test suite: 5 tests for markdown conversion and file utils (meson test)
- **#29** Auto-generated table of contents in PDF export