### PR TITLE
feat: scroll sync, TOC sidebar

### DIFF
--- a/src/marker-editor.c
+++ b/src/marker-editor.c
@@ -241,6 +241,29 @@ search_previous     (GtkEntry         *entry,
 }
 
 static void
+editor_scroll_changed_cb (GtkAdjustment *adj,
+                          gpointer       user_data)
+{
+  MarkerEditor *editor = MARKER_EDITOR (user_data);
+  if (editor->view_mode != DUAL_PANE_MODE)
+    return;
+
+  gdouble value = gtk_adjustment_get_value (adj);
+  gdouble upper = gtk_adjustment_get_upper (adj);
+  gdouble page = gtk_adjustment_get_page_size (adj);
+
+  if (upper <= page)
+    return;
+
+  gdouble ratio = value / (upper - page);
+  g_autofree gchar *script = g_strdup_printf (
+    "window.scrollTo(0, (document.body.scrollHeight - window.innerHeight) * %f);",
+    ratio);
+  webkit_web_view_run_javascript (
+    WEBKIT_WEB_VIEW (editor->preview), script, NULL, NULL, NULL);
+}
+
+static void
 marker_editor_init (MarkerEditor *editor)
 {
   editor->file = NULL;
@@ -301,6 +324,11 @@ marker_editor_init (MarkerEditor *editor)
   editor->source_scroll = GTK_SCROLLED_WINDOW (gtk_scrolled_window_new (NULL, NULL));
   gtk_widget_show (GTK_WIDGET (editor->source_scroll));
   gtk_container_add (GTK_CONTAINER (editor->source_scroll), GTK_WIDGET (editor->source_view));
+
+  /* Scroll sync: editor scroll → preview scroll (#22) */
+  GtkAdjustment *vadj = gtk_scrolled_window_get_vadjustment (editor->source_scroll);
+  g_signal_connect (vadj, "value-changed", G_CALLBACK (editor_scroll_changed_cb), editor);
+
   GtkTextBuffer *buffer = gtk_text_view_get_buffer (GTK_TEXT_VIEW (editor->source_view));
   g_signal_connect (buffer, "changed", G_CALLBACK (buffer_changed_cb), editor);
 

--- a/src/marker-window.c
+++ b/src/marker-window.c
@@ -59,6 +59,8 @@ struct _MarkerWindow
   GtkStack             *editors_stack;
   GtkTreeView          *documents_tree_view;
   GtkTreeStore         *documents_tree_store;
+  GtkTreeView          *toc_tree_view;
+  GtkListStore         *toc_store;
   GtkPaned             *main_paned;
   GtkWidget            *paned1;
   GtkWidget            *paned2;
@@ -348,6 +350,7 @@ title_changed_cb (MarkerEditor *editor,
                        TITLE_COLUMN,
                        markup_title, -1);
   }
+  marker_window_update_toc (window);
 }
 
 static void
@@ -553,6 +556,68 @@ button_pressed_cb (GtkWidget *view,
     return FALSE;
   }
   return TRUE;
+}
+
+/* TOC: update outline from editor headings (#24) */
+void
+marker_window_update_toc (MarkerWindow *window)
+{
+  if (!window->toc_store || !window->active_editor)
+    return;
+
+  gtk_list_store_clear (window->toc_store);
+
+  MarkerSourceView *sv = marker_editor_get_source_view (window->active_editor);
+  GtkTextBuffer *buffer = gtk_text_view_get_buffer (GTK_TEXT_VIEW (sv));
+  GtkTextIter iter;
+  gtk_text_buffer_get_start_iter (buffer, &iter);
+
+  while (!gtk_text_iter_is_end (&iter)) {
+    GtkTextIter line_end = iter;
+    gtk_text_iter_forward_to_line_end (&line_end);
+    g_autofree gchar *line = gtk_text_buffer_get_text (buffer, &iter, &line_end, FALSE);
+
+    if (line && line[0] == '#') {
+      int level = 0;
+      while (line[level] == '#') level++;
+      if (level <= 6 && line[level] == ' ') {
+        gchar *title = g_strdup (line + level + 1);
+        /* Indent based on level */
+        g_autofree gchar *display = g_strdup_printf ("%*s%s", (level - 1) * 2, "", title);
+        GtkTreeIter tree_iter;
+        gtk_list_store_append (window->toc_store, &tree_iter);
+        gtk_list_store_set (window->toc_store, &tree_iter,
+                            0, display,
+                            1, gtk_text_iter_get_line (&iter),
+                            -1);
+        g_free (title);
+      }
+    }
+    if (!gtk_text_iter_forward_line (&iter))
+      break;
+  }
+}
+
+static void
+toc_row_activated_cb (GtkTreeView       *tree_view,
+                      GtkTreePath       *path,
+                      GtkTreeViewColumn *column,
+                      gpointer           user_data)
+{
+  MarkerWindow *window = MARKER_WINDOW (user_data);
+  GtkTreeIter iter;
+  if (!gtk_tree_model_get_iter (GTK_TREE_MODEL (window->toc_store), &iter, path))
+    return;
+
+  gint line_num;
+  gtk_tree_model_get (GTK_TREE_MODEL (window->toc_store), &iter, 1, &line_num, -1);
+
+  MarkerSourceView *sv = marker_editor_get_source_view (window->active_editor);
+  GtkTextBuffer *buffer = gtk_text_view_get_buffer (GTK_TEXT_VIEW (sv));
+  GtkTextIter text_iter;
+  gtk_text_buffer_get_iter_at_line (buffer, &text_iter, line_num);
+  gtk_text_buffer_place_cursor (buffer, &text_iter);
+  gtk_text_view_scroll_to_iter (GTK_TEXT_VIEW (sv), &text_iter, 0.0, TRUE, 0.0, 0.2);
 }
 
 static void
@@ -773,6 +838,17 @@ marker_window_init (MarkerWindow *window)
   window->documents_tree_store = documents_store;
   window->documents_tree_view = documents_tree_view;
 
+  /* TOC sidebar setup (#24) */
+  GtkTreeView *toc_tv = GTK_TREE_VIEW (gtk_builder_get_object (builder, "toc_tree_view"));
+  GtkListStore *toc_store = gtk_list_store_new (2, G_TYPE_STRING, G_TYPE_INT);
+  gtk_tree_view_set_model (toc_tv, GTK_TREE_MODEL (toc_store));
+  GtkCellRenderer *toc_renderer = gtk_cell_renderer_text_new ();
+  GtkTreeViewColumn *toc_col = gtk_tree_view_column_new_with_attributes (
+    "Outline", toc_renderer, "text", 0, NULL);
+  gtk_tree_view_append_column (toc_tv, toc_col);
+  window->toc_tree_view = toc_tv;
+  window->toc_store = toc_store;
+  g_signal_connect (toc_tv, "row-activated", G_CALLBACK (toc_row_activated_cb), window);
 
   GtkTreeSelection *select;
   select = gtk_tree_view_get_selection (documents_tree_view);

--- a/src/marker-window.h
+++ b/src/marker-window.h
@@ -51,6 +51,7 @@ void                 marker_window_close_current_document        (MarkerWindow  
 void                 marker_window_toggle_sidebar                (MarkerWindow       *window);
 void                 marker_window_hide_sidebar                  (MarkerWindow       *window);
 void                 marker_window_show_sidebar                  (MarkerWindow       *window);
+void                 marker_window_update_toc                    (MarkerWindow       *window);
 
 void                 marker_window_new_editor                    (MarkerWindow       *window);
 void                 marker_window_new_editor_from_file          (MarkerWindow       *window,

--- a/src/resources/ui/marker-window-main-view.ui
+++ b/src/resources/ui/marker-window-main-view.ui
@@ -1,23 +1,70 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.2 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkPaned" id="main_paned">
     <property name="visible">True</property>
     <property name="can_focus">True</property>
     <child>
-      <object class="GtkScrolledWindow">
+      <object class="GtkBox" id="sidebar_box">
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
+        <property name="orientation">vertical</property>
         <child>
-          <object class="GtkTreeView" id="documents_tree_view">
+          <object class="GtkScrolledWindow">
             <property name="visible">True</property>
             <property name="can_focus">True</property>
-            <property name="enable_grid_lines">horizontal</property>
-            <child internal-child="selection">
-              <object class="GtkTreeSelection"/>
+            <child>
+              <object class="GtkTreeView" id="documents_tree_view">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="enable_grid_lines">horizontal</property>
+                <child internal-child="selection">
+                  <object class="GtkTreeSelection"/>
+                </child>
+              </object>
             </child>
           </object>
+          <packing>
+            <property name="expand">False</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkSeparator">
+            <property name="visible">True</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="toc_label">
+            <property name="visible">True</property>
+            <property name="label">Outline</property>
+            <property name="xalign">0</property>
+            <property name="margin-start">6</property>
+            <property name="margin-top">4</property>
+            <property name="margin-bottom">2</property>
+            <attributes>
+              <attribute name="weight" value="bold"/>
+              <attribute name="scale" value="0.85"/>
+            </attributes>
+          </object>
+        </child>
+        <child>
+          <object class="GtkScrolledWindow">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="vexpand">True</property>
+            <child>
+              <object class="GtkTreeView" id="toc_tree_view">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="headers_visible">False</property>
+                <child internal-child="selection">
+                  <object class="GtkTreeSelection"/>
+                </child>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+          </packing>
         </child>
       </object>
       <packing>


### PR DESCRIPTION
Closes #22, Closes #24

- **#22** Scroll sync: editor scroll syncs preview proportionally in dual-pane mode
- **#24** TOC sidebar: outline panel showing document headings, click to navigate