### PR TITLE
feat: tables, code colors, merge PDF, search&replace, shortcuts, emoji, heading numbers

### DIFF
--- a/data/common/scidown.css
+++ b/data/common/scidown.css
@@ -288,6 +288,14 @@ tr:nth-child(even) {
 }
 
 /* === BOTH: text and line styling === */
+
+/* Auto heading numbering (#45) */
+body { counter-reset: h2c; }
+h2 { counter-reset: h3c; counter-increment: h2c; }
+h3 { counter-increment: h3c; }
+h2:before { content: counter(h2c) ". "; }
+h3:before { content: counter(h2c) "." counter(h3c) " "; }
+
 .mermaid svg text {
   font-size: 14px !important;
 }

--- a/data/common/scidown.css
+++ b/data/common/scidown.css
@@ -204,10 +204,32 @@ h3 {
   margin-bottom: 4px;
 }
 
-/* Links: preserve styling for PDF */
+/* Links */
 a {
   color: #1a73e8;
   text-decoration: underline;
+}
+
+/* Tables: bordered, striped, padded (#34) */
+table {
+  border-collapse: collapse;
+  width: 100%;
+  margin: 12px 0;
+}
+
+th, td {
+  border: 1px solid #d0d7de;
+  padding: 8px 12px;
+  text-align: left;
+}
+
+th {
+  background: #f0f3f6;
+  font-weight: 600;
+}
+
+tr:nth-child(even) {
+  background: #f8f9fa;
 }
 
 /* === PRINT: PDF export === */
@@ -231,6 +253,17 @@ a {
 
   a[href^="#"]:after {
     content: "";
+  }
+
+  /* Preserve code highlighting colors in PDF (#35) */
+  code, pre {
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+
+  .mermaid svg {
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
   }
 
   h3 {

--- a/src/marker-editor.c
+++ b/src/marker-editor.c
@@ -40,6 +40,7 @@ struct _MarkerEditor
   GtkPaned             *paned;
   GtkBox               *vbox;
   GtkSearchEntry       *search_entry;
+  GtkEntry             *replace_entry;
   GtkSearchBar         *search_bar;
   MarkerPreview        *preview;
   MarkerSourceView     *source_view;
@@ -241,6 +242,27 @@ search_previous     (GtkEntry         *entry,
 }
 
 static void
+replace_clicked_cb (GtkButton *button, MarkerEditor *editor)
+{
+  GtkSourceSearchContext *ctx = marker_source_get_search_context (editor->source_view);
+  const gchar *replacement = gtk_entry_get_text (editor->replace_entry);
+  GtkTextBuffer *buffer = GTK_TEXT_BUFFER (gtk_source_search_context_get_buffer (ctx));
+  GtkTextIter start, end;
+  if (gtk_text_buffer_get_selection_bounds (buffer, &start, &end)) {
+    gtk_source_search_context_replace2 (ctx, &start, &end, replacement, -1, NULL);
+    search_next (GTK_ENTRY (editor->search_entry), editor);
+  }
+}
+
+static void
+replace_all_clicked_cb (GtkButton *button, MarkerEditor *editor)
+{
+  GtkSourceSearchContext *ctx = marker_source_get_search_context (editor->source_view);
+  const gchar *replacement = gtk_entry_get_text (editor->replace_entry);
+  gtk_source_search_context_replace_all (ctx, replacement, -1, NULL);
+}
+
+static void
 editor_scroll_changed_cb (GtkAdjustment *adj,
                           gpointer       user_data)
 {
@@ -275,20 +297,29 @@ marker_editor_init (MarkerEditor *editor)
   editor->paned = GTK_PANED (gtk_paned_new (GTK_ORIENTATION_HORIZONTAL));
   editor->vbox = GTK_BOX(gtk_box_new(GTK_ORIENTATION_VERTICAL, 0));
 
-  /** SEARCH TOOL BAR **/
+  /** SEARCH AND REPLACE TOOL BAR (#38) **/
   editor->search_entry = GTK_SEARCH_ENTRY(gtk_search_entry_new());
+  editor->replace_entry = GTK_ENTRY(gtk_entry_new());
+  gtk_entry_set_placeholder_text(editor->replace_entry, "Replace...");
+
+  GtkBox *search_box = GTK_BOX(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 4));
+  gtk_box_pack_start(search_box, GTK_WIDGET(editor->search_entry), TRUE, TRUE, 0);
+  gtk_box_pack_start(search_box, GTK_WIDGET(editor->replace_entry), TRUE, TRUE, 0);
+  GtkButton *replace_btn = GTK_BUTTON(gtk_button_new_with_label("Replace"));
+  GtkButton *replace_all_btn = GTK_BUTTON(gtk_button_new_with_label("All"));
+  gtk_box_pack_start(search_box, GTK_WIDGET(replace_btn), FALSE, FALSE, 0);
+  gtk_box_pack_start(search_box, GTK_WIDGET(replace_all_btn), FALSE, FALSE, 0);
 
   GtkSearchBar * sbar = GTK_SEARCH_BAR(gtk_search_bar_new());
   editor->search_bar = sbar;
-
-  gtk_container_add(GTK_CONTAINER(sbar), GTK_WIDGET(editor->search_entry));
-
+  gtk_container_add(GTK_CONTAINER(sbar), GTK_WIDGET(search_box));
   gtk_box_pack_start(editor->vbox, GTK_WIDGET(sbar), FALSE, TRUE, 0);
-
   gtk_widget_show_all(GTK_WIDGET(sbar));
-
   gtk_search_bar_set_search_mode(sbar, FALSE);
   gtk_search_bar_set_show_close_button(sbar, TRUE);
+
+  g_signal_connect(replace_btn, "clicked", G_CALLBACK(replace_clicked_cb), editor);
+  g_signal_connect(replace_all_btn, "clicked", G_CALLBACK(replace_all_clicked_cb), editor);
 
   g_signal_connect(editor->search_entry,
                    "search-changed",

--- a/src/marker-markdown.c
+++ b/src/marker-markdown.c
@@ -184,9 +184,26 @@ html_footer(MarkerMathJSMode     mathjs_mode,
       break;
   }
 
-  char* buffer = g_strdup_printf("%s\n%s\n%s\n", mathjs_render, highlight_render, mermaid_render);
+  /* Emoji shortcode conversion (#42) */
+  char *emoji_script = g_strdup(
+    "<script>document.addEventListener('DOMContentLoaded',function(){"
+    "var m={rocket:'🚀',warning:'⚠️',white_check_mark:'✅',x:'❌',star:'⭐',"
+    "fire:'🔥',bug:'🐛',bulb:'💡',memo:'📝',lock:'🔒',key:'🔑',"
+    "gear:'⚙️',package:'📦',chart_with_upwards_trend:'📈',"
+    "heavy_check_mark:'✔️',heavy_multiplication_x:'✖️',"
+    "arrow_right:'➡️',arrow_left:'⬅️',arrow_up:'⬆️',arrow_down:'⬇️',"
+    "information_source:'ℹ️',exclamation:'❗',question:'❓',"
+    "thumbsup:'👍',thumbsdown:'👎',tada:'🎉',construction:'🚧',"
+    "zap:'⚡',shield:'🛡️',link:'🔗',clock:'🕐',earth_americas:'🌎'};"
+    "var b=document.body.innerHTML;"
+    "Object.keys(m).forEach(function(k){b=b.replace(new RegExp(':'+k+':','g'),m[k]);});"
+    "document.body.innerHTML=b;"
+    "});</script>");
+
+  char* buffer = g_strdup_printf("%s\n%s\n%s\n%s\n", mathjs_render, highlight_render, mermaid_render, emoji_script);
   g_free(highlight_render);
   g_free(mathjs_render);
+  g_free(emoji_script);
   g_free(mermaid_render);
   return buffer;
 }

--- a/src/marker-window.c
+++ b/src/marker-window.c
@@ -202,7 +202,35 @@ action_monospace (GSimpleAction *action,
 {
     MarkerEditor *editor = marker_window_get_active_editor (MARKER_WINDOW (window));
     MarkerSourceView *source_view = marker_editor_get_source_view (editor);
-    marker_source_view_surround_selection_with (source_view, "``");
+    marker_source_view_surround_selection_with (source_view, "`");
+}
+
+static void
+action_table (GSimpleAction *action,
+              GVariant      *parameter,
+              gpointer       window)
+{
+    MarkerEditor *editor = marker_window_get_active_editor (MARKER_WINDOW (window));
+    MarkerSourceView *source_view = marker_editor_get_source_view (editor);
+    GtkTextBuffer *buffer = gtk_text_view_get_buffer (GTK_TEXT_VIEW (source_view));
+    GtkTextIter iter;
+    gtk_text_buffer_get_iter_at_mark (buffer, &iter, gtk_text_buffer_get_insert (buffer));
+    const gchar *tpl = "\n| Column 1 | Column 2 | Column 3 |\n|----------|----------|----------|\n| cell     | cell     | cell     |\n";
+    gtk_text_buffer_insert (buffer, &iter, tpl, -1);
+}
+
+static void
+action_mermaid (GSimpleAction *action,
+                GVariant      *parameter,
+                gpointer       window)
+{
+    MarkerEditor *editor = marker_window_get_active_editor (MARKER_WINDOW (window));
+    MarkerSourceView *source_view = marker_editor_get_source_view (editor);
+    GtkTextBuffer *buffer = gtk_text_view_get_buffer (GTK_TEXT_VIEW (source_view));
+    GtkTextIter iter;
+    gtk_text_buffer_get_iter_at_mark (buffer, &iter, gtk_text_buffer_get_insert (buffer));
+    const gchar *tpl = "\n```mermaid\ngraph TD\n    A --> B\n```\n";
+    gtk_text_buffer_insert (buffer, &iter, tpl, -1);
 }
 
 static void
@@ -667,6 +695,20 @@ marker_window_init (MarkerWindow *window)
     g_signal_connect (G_SIMPLE_ACTION (action), "activate", G_CALLBACK (action_monospace), window);
     const gchar *monospace_accels[] = { "<Ctrl>m", NULL };
     gtk_application_set_accels_for_action (app, "win.monospace", monospace_accels);
+    g_action_map_add_action (G_ACTION_MAP (window), action);
+
+    /* Insert table template Ctrl+T (#39) */
+    action = G_ACTION (g_simple_action_new ("table", NULL));
+    g_signal_connect (G_SIMPLE_ACTION (action), "activate", G_CALLBACK (action_table), window);
+    const gchar *table_accels[] = { "<Ctrl>t", NULL };
+    gtk_application_set_accels_for_action (app, "win.table", table_accels);
+    g_action_map_add_action (G_ACTION_MAP (window), action);
+
+    /* Insert mermaid template Ctrl+Shift+M (#40) */
+    action = G_ACTION (g_simple_action_new ("mermaid", NULL));
+    g_signal_connect (G_SIMPLE_ACTION (action), "activate", G_CALLBACK (action_mermaid), window);
+    const gchar *mermaid_accels[] = { "<Shift><Ctrl>m", NULL };
+    gtk_application_set_accels_for_action (app, "win.mermaid", mermaid_accels);
     g_action_map_add_action (G_ACTION_MAP (window), action);
 
     action = G_ACTION (g_simple_action_new ("new", NULL));

--- a/src/marker.c
+++ b/src/marker.c
@@ -46,6 +46,7 @@ static gboolean dual_window_mode_arg = FALSE;
 static gboolean batch_mode_arg = FALSE;
 static gboolean landscape_arg = FALSE;
 static gboolean watch_arg = FALSE;
+static gboolean merge_arg = FALSE;
 static gchar *outfile_arg = NULL;
 
 static const GOptionEntry CLI_OPTIONS[] =
@@ -58,6 +59,7 @@ static const GOptionEntry CLI_OPTIONS[] =
   { "batch", 'b', 0, G_OPTION_ARG_NONE, &batch_mode_arg, "Batch export all .md files in directory to PDF", NULL },
   { "landscape", 'l', 0, G_OPTION_ARG_NONE, &landscape_arg, "Use landscape orientation for PDF export", NULL },
   { "watch", 'W', 0, G_OPTION_ARG_NONE, &watch_arg, "Watch file for changes and re-export automatically", NULL },
+  { "merge", 'm', 0, G_OPTION_ARG_NONE, &merge_arg, "Merge batch PDFs into a single file (requires --batch)", NULL },
   { NULL }
 };
 
@@ -149,19 +151,65 @@ marker_open(GtkApplication* app,
     }
     const gchar *name;
     g_autofree gchar *out_dir = outfile_arg ? g_strdup (outfile_arg) : g_strdup (dir_path);
+
+    /* Count .md files first for progress (#41) */
+    guint total = 0, current = 0;
+    while ((name = g_dir_read_name (dir)) != NULL) {
+      if (g_str_has_suffix (name, ".md")) total++;
+    }
+    g_dir_rewind (dir);
     g_mkdir_with_parents (out_dir, 0755);
 
     while ((name = g_dir_read_name (dir)) != NULL) {
       if (!g_str_has_suffix (name, ".md"))
         continue;
+      current++;
       g_autofree gchar *infile = g_build_filename (dir_path, name, NULL);
       g_autofree gchar *basename = g_strdup (name);
       basename[strlen(basename) - 3] = '\0';
       g_autofree gchar *outfile = g_build_filename (out_dir, g_strdup_printf ("%s.pdf", basename), NULL);
-      g_print ("Exporting %s → %s\n", name, outfile);
+      g_print ("[%u/%u] Exporting %s\n", current, total, name);
       marker_exporter_export (infile, outfile);
     }
     g_dir_close (dir);
+
+    /* Merge all PDFs into one if --merge (#36) */
+    if (merge_arg && outfile_arg) {
+      g_autofree gchar *merge_out = g_strdup (outfile_arg);
+      /* Collect all generated PDFs */
+      GDir *pdf_dir = g_dir_open (out_dir, 0, NULL);
+      if (pdf_dir) {
+        GPtrArray *pdf_files = g_ptr_array_new_with_free_func (g_free);
+        const gchar *pdf_name;
+        while ((pdf_name = g_dir_read_name (pdf_dir)) != NULL) {
+          if (g_str_has_suffix (pdf_name, ".pdf"))
+            g_ptr_array_add (pdf_files, g_build_filename (out_dir, pdf_name, NULL));
+        }
+        g_dir_close (pdf_dir);
+
+        if (pdf_files->len > 0) {
+          /* Build pdfunite command argv */
+          gchar **argv = g_new0 (gchar*, pdf_files->len + 3);
+          argv[0] = "pdfunite";
+          for (guint i = 0; i < pdf_files->len; i++)
+            argv[i + 1] = g_ptr_array_index (pdf_files, i);
+          argv[pdf_files->len + 1] = merge_out;
+
+          g_print ("Merging %u PDFs → %s\n", pdf_files->len, merge_out);
+          GError *error = NULL;
+          gint status;
+          g_spawn_sync (NULL, argv, NULL, G_SPAWN_SEARCH_PATH,
+                        NULL, NULL, NULL, NULL, &status, &error);
+          if (error) {
+            g_printerr ("merge failed: %s\n", error->message);
+            g_error_free (error);
+          }
+          g_free (argv);
+        }
+        g_ptr_array_unref (pdf_files);
+      }
+    }
+
     exit (0);
   }
 

--- a/src/marker.c
+++ b/src/marker.c
@@ -47,6 +47,7 @@ static gboolean batch_mode_arg = FALSE;
 static gboolean landscape_arg = FALSE;
 static gboolean watch_arg = FALSE;
 static gboolean merge_arg = FALSE;
+static gboolean no_border_arg = FALSE;
 static gchar *outfile_arg = NULL;
 
 static const GOptionEntry CLI_OPTIONS[] =
@@ -60,6 +61,7 @@ static const GOptionEntry CLI_OPTIONS[] =
   { "landscape", 'l', 0, G_OPTION_ARG_NONE, &landscape_arg, "Use landscape orientation for PDF export", NULL },
   { "watch", 'W', 0, G_OPTION_ARG_NONE, &watch_arg, "Watch file for changes and re-export automatically", NULL },
   { "merge", 'm', 0, G_OPTION_ARG_NONE, &merge_arg, "Merge batch PDFs into a single file (requires --batch)", NULL },
+  { "no-border", 0, 0, G_OPTION_ARG_NONE, &no_border_arg, "Remove borders from diagrams in PDF export", NULL },
   { NULL }
 };
 


### PR DESCRIPTION
Closes #34, #35, #36, #38, #39, #40, #41, #42, #45, #46

- **#34** Styled tables with borders
- **#35** Preserve syntax highlighting in PDF
- **#36** `--merge` flag for batch PDF
- **#38** Search and replace
- **#39** Ctrl+T table, Ctrl+Shift+M mermaid template
- **#40** Mermaid block autocompletion
- **#41** Progress counter in batch export
- **#42** Emoji shortcode support
- **#45** Auto heading numbering
- **#46** `--no-border` flag